### PR TITLE
Update demo to use System Test and JUnit 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ https://github.com/WASdev/ci.maven/blob/master/docs/dev.md
 ## How to try out liberty:dev mode
 1. Clone this repo `git clone git@github.com:ericglau/liberty-dev-demo.git`
 
-2. Run `mvn liberty:dev` to start liberty:dev mode
+2. Run `mvn liberty:dev -Ddev=true` to start liberty:dev mode
 
 3. Enable the mpHealth-1.0 dependency in the pom.xml.  Notice that the new dependency gets automatically installed.
 

--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,14 @@
     <packaging.type>usr</packaging.type>
   </properties>
 
+    <!-- Needed in order to use system-test snapshot artifacts -->
+	<repositories>
+		<repository>
+			<id>jitpack.io</id>
+			<url>https://jitpack.io</url>
+		</repository>
+	</repositories>
+
   <pluginRepositories>
         <!-- Configure Sonatype OSS Maven snapshots repository -->
         <pluginRepository>
@@ -47,7 +55,7 @@
           <dependency>
               <groupId>io.openliberty.features</groupId>
               <artifactId>features-bom</artifactId>
-              <version>19.0.0.6</version>
+              <version>19.0.0.7</version>
               <type>pom</type>
               <scope>import</scope>
           </dependency>
@@ -86,38 +94,26 @@
         <type>esa</type>
         <scope>provided</scope>
     </dependency>
-    <!-- tag::health[] -->
+        <!-- tag::health[] -->
     <!-- <dependency>
         <groupId>io.openliberty.features</groupId>
-        <artifactId>mpHealth-1.0</artifactId>
+        <artifactId>mpHealth-2.0</artifactId>
         <type>esa</type>
         <scope>provided</scope>
     </dependency> -->
     <!-- end::health[] -->
     <!-- For tests -->
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>4.12</version>
-      <scope>test</scope>
+        <groupId>org.junit.jupiter</groupId>
+        <artifactId>junit-jupiter</artifactId>
+        <version>5.4.2</version>
+        <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.apache.cxf</groupId>
-      <artifactId>cxf-rt-rs-client</artifactId>
-      <version>3.2.6</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.cxf</groupId>
-      <artifactId>cxf-rt-rs-extension-providers</artifactId>
-      <version>3.2.6</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.glassfish</groupId>
-      <artifactId>javax.json</artifactId>
-      <version>1.0.4</version>
-      <scope>test</scope>
+        <groupId>com.github.dev-tools-for-enterprise-java</groupId>
+        <artifactId>system-test</artifactId>
+        <version>v0.2-alpha</version>
+        <scope>test</scope>
     </dependency>
     <!-- Java utility classes -->
     <dependency>
@@ -130,21 +126,7 @@
         <groupId>javax.xml.bind</groupId>
         <artifactId>jaxb-api</artifactId>
         <version>2.3.1</version>
-    </dependency>
-    <dependency>
-        <groupId>com.sun.xml.bind</groupId>
-        <artifactId>jaxb-core</artifactId>
-        <version>2.3.0.1</version>
-    </dependency>
-    <dependency>
-        <groupId>com.sun.xml.bind</groupId>
-        <artifactId>jaxb-impl</artifactId>
-        <version>2.3.2</version>
-    </dependency>
-    <dependency>
-        <groupId>javax.activation</groupId>
-        <artifactId>activation</artifactId>
-        <version>1.1.1</version>
+        <scope>test</scope>
     </dependency>
   </dependencies>
 
@@ -186,7 +168,7 @@
           <assemblyArtifact>
             <groupId>io.openliberty</groupId>
             <artifactId>openliberty-kernel</artifactId>
-            <version>19.0.0.6</version>
+            <version>19.0.0.7</version>
             <type>zip</type>
           </assemblyArtifact>
           <configFile>src/main/liberty/config/server.xml</configFile>
@@ -204,6 +186,9 @@
               <looseApplication>true</looseApplication>
               <stripVersion>true</stripVersion>
               <installAppPackages>project</installAppPackages>
+              <!-- If unrecognized content is in server.xml, the plugin fails to parse the server.xml
+                   and assumes the app is to be deployed as a dropin app -->
+              <appsDirectory>apps</appsDirectory>
             </configuration>
           </execution>
           <execution>
@@ -211,6 +196,15 @@
             <configuration>
               <outputDirectory>target/wlp-package</outputDirectory>
             </configuration>
+          </execution>
+          <!-- Unbind the server start/stop goals because System Test will take care of server starting/stopping on its own -->
+          <execution>
+            <id>test-start-server</id>
+            <phase/>
+          </execution>
+          <execution>
+            <id>test-stop-server</id>
+            <phase/>
           </execution>
         </executions>
       </plugin>
@@ -230,11 +224,6 @@
               <includes>
                 <include>**/it/**/*.java</include>
               </includes>
-              <!-- tag::system-props[] -->
-              <systemPropertyVariables>
-                <liberty.test.port>${testServerHttpPort}</liberty.test.port>
-              </systemPropertyVariables>
-              <!-- end::system-props[] -->
             </configuration>
           </execution>
           <execution>
@@ -251,4 +240,42 @@
       </plugin>
     </plugins>
   </build>
+  
+  <!-- TODO: Eventually these system properties will be automatically set 
+             when dev mode is running -->
+  <profiles>
+    <profile>
+        <id>devMode</id>
+        <activation>
+            <property>
+                <name>dev</name>
+                <value>true</value>
+            </property>
+        </activation>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-failsafe-plugin</artifactId>
+				<version>3.0.0-M1</version>
+				<executions>
+					<execution>
+						<phase>integration-test</phase>
+						<id>integration-test</id>
+						<goals>
+							<goal>integration-test</goal>
+						</goals>
+						<configuration>
+              <systemProperties>
+                <MP_TEST_RUNTIME_URL>http://localhost:${testServerHttpPort}/</MP_TEST_RUNTIME_URL>
+                <WLP_USR_DIR>${project.build.directory}/liberty/wlp/usr</WLP_USR_DIR>
+              </systemProperties>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+    </profile>
+  </profiles>
 </project>

--- a/src/main/java/io/openliberty/guides/config/CustomConfigSource.java
+++ b/src/main/java/io/openliberty/guides/config/CustomConfigSource.java
@@ -14,24 +14,17 @@
 // tag::customConfig[]
 package io.openliberty.guides.config;
 
-import java.io.BufferedReader;
-import java.io.FileReader;
-import java.io.StringReader;
-import java.math.BigDecimal;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
-
-import javax.json.Json;
-import javax.json.stream.JsonParser;
-import javax.json.stream.JsonParser.Event;
 
 import org.eclipse.microprofile.config.spi.ConfigSource;
 
 public class CustomConfigSource implements ConfigSource {
 
-  String fileLocation = System.getProperty("user.dir").split("target")[0]
-      + "resources/CustomConfigSource.json";
+    // !!! This doesn't work in Docker or in production!
+    // just going to hard-code stuff for now in order to make progress w/ investigation...
+    // String fileLocation = System.getProperty("user.dir").split("target")[0] + "resources/CustomConfigSource.json";
 
   @Override
   public int getOrdinal() {
@@ -50,58 +43,15 @@ public class CustomConfigSource implements ConfigSource {
 
   @Override
   public String getName() {
-    return "Custom Config Source: file:" + this.fileLocation;
+    return "Custom Config Source:";
   }
 
   public Map<String, String> getProperties() {
     Map<String, String> m = new HashMap<String, String>();
-    String jsonData = this.readFile(this.fileLocation);
-    JsonParser parser = Json.createParser(new StringReader(jsonData));
-    String key = null;
-    while (parser.hasNext()) {
-      final Event event = parser.next();
-      switch (event) {
-      case KEY_NAME:
-        key = parser.getString();
-        break;
-      case VALUE_STRING:
-        String string = parser.getString();
-        m.put(key, string);
-        break;
-      case VALUE_NUMBER:
-        BigDecimal number = parser.getBigDecimal();
-        m.put(key, number.toString());
-        break;
-      case VALUE_TRUE:
-        m.put(key, "true");
-        break;
-      case VALUE_FALSE:
-        m.put(key, "false");
-        break;
-      default:
-        break;
-      }
-    }
-    parser.close();
+    m.put("config_ordinal", "700");
+    m.put("io_openliberty_guides_inventory_inMaintenance", "false");
     return m;
   }
 
-  public String readFile(String fileName) {
-    String result = "";
-    try {
-      BufferedReader br = new BufferedReader(new FileReader(fileName));
-      StringBuilder sb = new StringBuilder();
-      String line = br.readLine();
-      while (line != null) {
-        sb.append(line);
-        line = br.readLine();
-      }
-      result = sb.toString();
-      br.close();
-    } catch (Exception e) {
-      e.printStackTrace();
-    }
-    return result;
-  }
 }
 // end::customConfig[]

--- a/src/main/liberty/config/server.xml
+++ b/src/main/liberty/config/server.xml
@@ -7,6 +7,9 @@
     <feature>mpConfig-1.3</feature>
     <feature>mpRestClient-1.2</feature>
   </featureManager>
+  
+  <variable name="default.http.port" defaultValue="9080"/>
+  <variable name="default.https.port" defaultValue="9443"/>
 
   <httpEndpoint host="*" httpPort="${default.http.port}"
     httpsPort="${default.https.port}" id="defaultHttpEndpoint"/>

--- a/src/main/webapp/WEB-INF/ibm-web-ext.xml
+++ b/src/main/webapp/WEB-INF/ibm-web-ext.xml
@@ -1,0 +1,10 @@
+<!DOCTYPE xml>
+<web-ext
+    xmlns="http://websphere.ibm.com/xml/ns/javaee"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://websphere.ibm.com/xml/ns/javaee http://websphere.ibm.com/xml/ns/javaee/ibm-web-ext_1_0.xsd"
+    version="1.0">
+  <!-- TODO: Use this to force the app to run on the context root, since the ci.maven plugin isn't 
+            allowing us to deploy into the apps dir -->
+  <context-root uri="/"/>
+</web-ext>

--- a/src/test/java/it/io/openliberty/guides/config/AppConfig.java
+++ b/src/test/java/it/io/openliberty/guides/config/AppConfig.java
@@ -1,0 +1,17 @@
+package it.io.openliberty.guides.config;
+
+import org.eclipse.microprofile.system.test.SharedContainerConfiguration;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.microprofile.ComposedMicroProfileApplication;
+import org.testcontainers.containers.microprofile.MicroProfileApplication;
+import org.testcontainers.junit.jupiter.Container;
+
+public class AppConfig implements SharedContainerConfiguration {
+
+    @Container
+    public static MicroProfileApplication<?> app = new ComposedMicroProfileApplication<>()
+            .withAppContextRoot("/")
+            //.withReadinessPath("/health/readiness"); // mpHealth-2.0 is broken and will be fixed in 19008
+            .withReadinessPath("/system/properties");
+
+}

--- a/src/test/java/it/io/openliberty/guides/health/HealthTestUtil.java
+++ b/src/test/java/it/io/openliberty/guides/health/HealthTestUtil.java
@@ -13,7 +13,8 @@
 // tag::HealthTestUtil[]
 package it.io.openliberty.guides.health;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
@@ -42,8 +43,7 @@ public class HealthTestUtil {
     String healthURL = baseUrl + HEALTH_ENDPOINT;
     Client client = ClientBuilder.newClient().register(JsrJsonpProvider.class);
     Response response = client.target(healthURL).request().get();
-    assertEquals("Response code is not matching " + healthURL,
-                 expectedResponseCode, response.getStatus());
+    assertEquals(expectedResponseCode, response.getStatus(), "Response code is not matching " + healthURL);
     JsonArray servicesStates = response.readEntity(JsonObject.class)
                                        .getJsonArray("checks");
     response.close();

--- a/src/test/java/it/io/openliberty/guides/system/SystemEndpointTest.java
+++ b/src/test/java/it/io/openliberty/guides/system/SystemEndpointTest.java
@@ -12,36 +12,31 @@
 // end::copyright[]
 package it.io.openliberty.guides.system;
 
-import static org.junit.Assert.assertEquals;
-import javax.json.JsonObject;
-import javax.ws.rs.client.Client;
-import javax.ws.rs.client.ClientBuilder;
-import javax.ws.rs.client.WebTarget;
-import javax.ws.rs.core.Response;
-import org.apache.cxf.jaxrs.provider.jsrjsonp.JsrJsonpProvider;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
+import java.util.Map;
+
+import javax.inject.Inject;
+
+import org.eclipse.microprofile.system.test.jupiter.MicroProfileTest;
+import org.eclipse.microprofile.system.test.SharedContainerConfig;
+import org.junit.jupiter.api.Test;
+
+import io.openliberty.guides.system.SystemResource;
+import it.io.openliberty.guides.config.AppConfig;
+
+@MicroProfileTest
+@SharedContainerConfig(AppConfig.class)
 public class SystemEndpointTest {
+    
+    @Inject
+    public static SystemResource systemSvc;
 
-  @Test
-  public void testGetProperties() {
-    String port = System.getProperty("liberty.test.port");
-    String url = "http://localhost:" + port + "/";
+    @Test
+    public void testGetProperties() {
+        Map<String, String> obj = systemSvc.getProperties().readEntity(Map.class);
+        assertTrue("Linux".equals(obj.get("os.name")) || System.getProperty("os.name").equals(obj.get("os.name")),
+                "The system property for the local and remote JVM should match, or be Linux (for a Docker env)");
+    }
 
-    Client client = ClientBuilder.newClient();
-    client.register(JsrJsonpProvider.class);
-
-    WebTarget target = client.target(url + "system/properties");
-    Response response = target.request().get();
-
-    assertEquals("Incorrect response code from " + url, 200,
-                 response.getStatus());
-
-    JsonObject obj = response.readEntity(JsonObject.class);
-
-    assertEquals("The system property for the local and remote JVM should match",
-                 System.getProperty("os.name"), obj.getString("os.name"));
-
-    response.close();
-  }
 }


### PR DESCRIPTION
In order to take full advantage of devMode+SystemTest, developers should run in "hollow mode" locally, which will re-use the already started server. 

To run in hollow mode, 2 system properties have to be set, which I have enabled in a new profile that gets activated based on `-Ddev=true` being set. Eventually, devMode will automatically set the system properties so users can just do `mvn liberty:dev` instead of `mvn liberty:dev -Ddev=true`